### PR TITLE
feat: Add Helm chart for CAST AI PDB Controller

### DIFF
--- a/helm/castai-pdb-controller/Chart.yaml
+++ b/helm/castai-pdb-controller/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: castai-pdb-controller
+description: A Helm chart for CAST AI PDB Controller
+type: application
+version: 0.1.0
+appVersion: "1.32"
+maintainers:
+  - name: CAST AI 

--- a/helm/castai-pdb-controller/README.md
+++ b/helm/castai-pdb-controller/README.md
@@ -1,0 +1,143 @@
+# CAST AI PDB Controller Helm Chart
+
+A Helm chart for deploying the CAST AI Pod Disruption Budget (PDB) Controller to Kubernetes clusters.
+
+## Overview
+
+The CAST AI PDB Controller automatically creates, updates, and manages PodDisruptionBudgets for Deployments and StatefulSets in your Kubernetes cluster. It ensures high availability during cluster maintenance and node disruptions.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+- Cluster admin permissions (for RBAC resources)
+
+## Deployment
+
+### Basic Installation
+
+```bash
+# Install the chart
+helm install castai-pdb-controller ./helm/castai-pdb-controller
+```
+
+### Installation with Custom Values
+
+```bash
+# Install with custom namespace
+helm install castai-pdb-controller ./helm/castai-pdb-controller \
+  --set namespace=my-namespace
+
+# Install with custom PDB configuration
+helm install castai-pdb-controller ./helm/castai-pdb-controller \
+  --set config.minAvailable="2" \
+  --set config.fixPoorPDBs=true
+```
+
+### Using Custom Values File
+
+Create a `custom-values.yaml`:
+
+```yaml
+replicaCount: 3
+namespace: my-custom-namespace
+
+config:
+  minAvailable: "2"
+  fixPoorPDBs: "true"
+```
+
+Install with custom values:
+```bash
+helm install castai-pdb-controller ./helm/castai-pdb-controller -f custom-values.yaml
+```
+
+## Configuration
+
+### Values Reference
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of controller replicas | `2` |
+| `image.repository` | Container image repository | `tylerwagner/castai-pdb-controller` |
+| `image.tag` | Container image tag | `"1.32"` |
+| `image.pullPolicy` | Container image pull policy | `IfNotPresent` |
+| `nameOverride` | Override the chart name | `""` |
+| `fullnameOverride` | Override the full app name | `""` |
+| `serviceAccount.create` | Create a new service account | `true` |
+| `serviceAccount.name` | Service account name | `"castai-pdb-controller"` |
+| `serviceAccount.annotations` | Service account annotations | `{}` |
+| `rbac.create` | Create RBAC resources | `true` |
+| `config.minAvailable` | Default minAvailable for PDBs | `"1"` |
+| `config.maxUnavailable` | Default maxUnavailable for PDBs | `""` (unset) |
+| `config.fixPoorPDBs` | Automatically fix poor PDB configurations | `"false"` |
+| `namespace` | Target namespace for deployment | `castai-agent` |
+
+### PDB Configuration
+
+The controller supports two PDB configuration modes:
+
+#### MinAvailable Mode (Default)
+```yaml
+config:
+  minAvailable: "1"  # Ensures at least 1 pod is always available
+```
+
+#### MaxUnavailable Mode
+```yaml
+config:
+  maxUnavailable: "50%"  # Allows up to 50% of pods to be unavailable
+```
+
+**Note**: Use either `minAvailable` or `maxUnavailable`, not both.
+
+## Monitoring
+
+### Check Controller Status
+
+```bash
+# Check pods
+kubectl get pods -n castai-agent -l app=castai-pdb-controller
+
+# Check logs
+kubectl logs deployment/castai-pdb-controller -n castai-agent
+
+# Check created PDBs
+kubectl get pdb -A | grep castai
+```
+
+### Check Controller Health
+
+```bash
+# Check deployment status
+kubectl get deployment castai-pdb-controller -n castai-agent
+
+# Check events
+kubectl get events -n castai-agent --sort-by='.lastTimestamp'
+
+# Check RBAC permissions
+kubectl auth can-i create poddisruptionbudgets --as=system:serviceaccount:castai-agent:castai-pdb-controller
+```
+
+## Upgrading
+
+```bash
+# Update to a new version
+helm upgrade castai-pdb-controller ./helm/castai-pdb-controller
+
+# Upgrade with new values
+helm upgrade castai-pdb-controller ./helm/castai-pdb-controller \
+  --set image.tag="1.33" \
+  --set config.minAvailable="2"
+```
+
+## Uninstalling
+
+```bash
+# Uninstall the chart
+helm uninstall castai-pdb-controller
+
+# Remove RBAC resources (if not managed by Helm)
+kubectl delete clusterrole castai-pdb-controller
+kubectl delete clusterrolebinding castai-pdb-controller
+``` 

--- a/helm/castai-pdb-controller/templates/_helpers.tpl
+++ b/helm/castai-pdb-controller/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "castai-pdb-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "castai-pdb-controller.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "castai-pdb-controller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "castai-pdb-controller.labels" -}}
+helm.sh/chart: {{ include "castai-pdb-controller.chart" . }}
+app.kubernetes.io/name: {{ include "castai-pdb-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }} 

--- a/helm/castai-pdb-controller/templates/configmap.yaml
+++ b/helm/castai-pdb-controller/templates/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "castai-pdb-controller.fullname" . }}-config
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "castai-pdb-controller.labels" . | nindent 4 }}
+data:
+  minAvailable: {{ .Values.config.minAvailable | quote }}
+  {{- if .Values.config.maxUnavailable }}
+  maxUnavailable: {{ .Values.config.maxUnavailable | quote }}
+  {{- end }}
+  FixPoorPDBs: {{ .Values.config.fixPoorPDBs | quote }} 

--- a/helm/castai-pdb-controller/templates/deployment.yaml
+++ b/helm/castai-pdb-controller/templates/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "castai-pdb-controller.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "castai-pdb-controller.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "castai-pdb-controller.labels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "castai-pdb-controller.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }} 

--- a/helm/castai-pdb-controller/templates/rbac.yaml
+++ b/helm/castai-pdb-controller/templates/rbac.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "castai-pdb-controller.fullname" . }}
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments", "statefulsets", "replicasets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "list", "watch", "create", "update", "delete"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "castai-pdb-controller.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "castai-pdb-controller.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Values.namespace }}
+{{- end }} 

--- a/helm/castai-pdb-controller/templates/serviceaccount.yaml
+++ b/helm/castai-pdb-controller/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Values.namespace }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }} 

--- a/helm/castai-pdb-controller/values.yaml
+++ b/helm/castai-pdb-controller/values.yaml
@@ -1,0 +1,42 @@
+# Default values for castai-pdb-controller
+# Number of controller replicas to deploy
+replicaCount: 2
+
+# Container image configuration
+image:
+  # Container image repository
+  repository: tylerwagner/castai-pdb-controller
+  # Container image tag
+  tag: "1.32"
+  # Container image pull policy
+  pullPolicy: IfNotPresent
+
+# Name overrides for the chart
+nameOverride: ""
+fullnameOverride: ""
+
+# ServiceAccount configuration
+serviceAccount:
+  # Create a new service account
+  create: true
+  # Service account name
+  name: "castai-pdb-controller"
+  # Service account annotations (useful for IAM roles, etc.)
+  annotations: {}
+
+# RBAC configuration
+rbac:
+  # Create RBAC resources (ClusterRole and ClusterRoleBinding)
+  create: true
+
+# Controller configuration
+config:
+  # Default minAvailable for PDBs (use either minAvailable or maxUnavailable, not both)
+  minAvailable: "1"
+  # Default maxUnavailable for PDBs (use either minAvailable or maxUnavailable, not both)
+  # maxUnavailable: "50%"  # Optional, use one or the other
+  # Automatically fix poor PDB configurations (true/false)
+  fixPoorPDBs: "false"    # Set to "true" for automatic correction, "false" for logging only
+
+# Target namespace for deployment
+namespace: castai-agent 


### PR DESCRIPTION
**Summary**
Adds a complete Helm chart for easy deployment and configuration of the CAST AI PDB Controller.

**What's Added**
Helm Chart: Complete chart structure with templated manifests
Documentation: README with deployment and configuration guide
Flexible Config: Support for custom namespaces, replicas, and PDB settings

**Files**
- helm/castai-pdb-controller/ - Complete chart with templates and docs
- Image aligned with current deployment (1.32)
- No breaking changes
