### PR TITLE
Update Helm chart to use official CAST AI PDB Controller image

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: castai-pdb-controller
       containers:
       - name: castai-pdb-controller
-        image: tylerwagner/castai-pdb-controller:1.32
+        image: castai/castai-pdb-controller:latest
 
 
 

--- a/helm/castai-pdb-controller/Chart.yaml
+++ b/helm/castai-pdb-controller/Chart.yaml
@@ -3,6 +3,6 @@ name: castai-pdb-controller
 description: A Helm chart for CAST AI PDB Controller
 type: application
 version: 0.1.0
-appVersion: "1.32"
+appVersion: "latest"
 maintainers:
   - name: CAST AI 

--- a/helm/castai-pdb-controller/README.md
+++ b/helm/castai-pdb-controller/README.md
@@ -59,8 +59,8 @@ helm install castai-pdb-controller ./helm/castai-pdb-controller -f custom-values
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `replicaCount` | Number of controller replicas | `2` |
-| `image.repository` | Container image repository | `tylerwagner/castai-pdb-controller` |
-| `image.tag` | Container image tag | `"1.32"` |
+| `image.repository` | Container image repository | `castai/castai-pdb-controller` |
+| `image.tag` | Container image tag | `"latest"` |
 | `image.pullPolicy` | Container image pull policy | `IfNotPresent` |
 | `nameOverride` | Override the chart name | `""` |
 | `fullnameOverride` | Override the full app name | `""` |
@@ -127,7 +127,7 @@ helm upgrade castai-pdb-controller ./helm/castai-pdb-controller
 
 # Upgrade with new values
 helm upgrade castai-pdb-controller ./helm/castai-pdb-controller \
-  --set image.tag="1.33" \
+  --set image.tag="latest" \
   --set config.minAvailable="2"
 ```
 

--- a/helm/castai-pdb-controller/values.yaml
+++ b/helm/castai-pdb-controller/values.yaml
@@ -5,9 +5,9 @@ replicaCount: 2
 # Container image configuration
 image:
   # Container image repository
-  repository: tylerwagner/castai-pdb-controller
+  repository: castai/castai-pdb-controller
   # Container image tag
-  tag: "1.32"
+  tag: "latest"
   # Container image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Summary:

- Updates the Helm chart to use the official image: castai/castai-pdb-controller:latest
- Updates documentation and chart metadata to reflect the new image
- Verified deployment and functionality with the new image